### PR TITLE
Update terragrunt path for dev cognito

### DIFF
--- a/infrastructure/terraform/environment/dev/cognito/terragrunt.hcl
+++ b/infrastructure/terraform/environment/dev/cognito/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 terraform {
-  source = "../../../modules/cognito"
+  source = "../../../../terraform_modules/cognito"
 }
 
 inputs = {


### PR DESCRIPTION
## Summary
- fix the `terraform` source path for dev cognito configuration

## Testing
- `terragrunt --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848808f4af88331afce1c3d8e93a6e1