### PR TITLE
Add Lambda build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ export TG_STATE_BUCKET=laas-dev-tfstate
 export TG_REGION=us-west-2
 ```
 
+Before applying Terragrunt, build the Lambda deployment package:
+
+```bash
+cd infrastructure/terraform_modules/lambda
+./build.sh
+```
+
 Run `terragrunt run-all apply` from the desired environment directory to deploy.
 
 ## Prerequisites

--- a/infrastructure/terraform_modules/lambda/build.sh
+++ b/infrastructure/terraform_modules/lambda/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+ZIP_NAME="lambda.zip"
+
+rm -f "$ZIP_NAME"
+
+# Install dependencies if a requirements file exists
+if [ -f requirements.txt ]; then
+  temp_dir="$(mktemp -d)"
+  pip install -r requirements.txt -t "$temp_dir"
+  (cd "$temp_dir" && zip -r9 "$SCRIPT_DIR/$ZIP_NAME" .)
+  rm -rf "$temp_dir"
+fi
+
+# Always add the handler file
+zip -g "$ZIP_NAME" handler.py > /dev/null
+
+echo "Created $ZIP_NAME"


### PR DESCRIPTION
## Summary
- add `build.sh` to zip Lambda handler
- document running `build.sh` in README before applying Terragrunt

## Testing
- `bash infrastructure/terraform_modules/lambda/build.sh`
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848848c40a88331a53208bc972fbb8c