### PR TITLE
Update API documentation and web form

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,25 @@ Terragrunt will provision all buckets, roles, the Lambda function, API Gateway, 
 
 Upload an HTML file (for example `index.html`) to the `s3_input` bucket created
 during deployment. The Lambda reads this template from S3. To trigger the page
-generation you POST a JSON payload describing your modifications to the API
-Gateway endpoint. An invocation using `curl` might look like:
+generation you POST a JSON payload with the following fields to the API Gateway
+endpoint:
+
+```
+{
+  "imagen": "URL de la imagen",
+  "titulo": "Título principal",
+  "subtitulo": "Subtítulo",
+  "beneficios": "Lista o descripción de beneficios",
+  "cta": "Texto del botón CTA"
+}
+```
+
+An invocation using `curl` might look like:
 
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{"modifications": "Make all headings blue"}' \
+  -d '{"imagen":"https://example.com/hero.jpg","titulo":"Mi producto","subtitulo":"Subtítulo","beneficios":"Beneficio 1\nBeneficio 2","cta":"Comprar"}' \
   $(terragrunt output -raw api_endpoint)
 ```
 
@@ -107,8 +119,9 @@ Follow these steps to try the simple front‑end included under `web/`:
 
    Then open the printed URL in your browser.
 
-Submitting the form sends a JSON body containing your modifications to the
-configured API Gateway endpoint. API Gateway invokes the Lambda function, which
+Submitting the form sends a JSON body containing `imagen`, `titulo`, `subtitulo`,
+`beneficios` and `cta` to the configured API Gateway endpoint. API Gateway invokes
+the Lambda function, which
 returns the location of the generated page. The script in `main.js` redirects
 the browser to that URL (using `cloudfrontUrl` if only a path is returned).
 

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,11 @@
         <button id="login">Login</button>
     </div>
     <div id="form" style="display:none;">
-        <textarea id="modifications" placeholder="Describe your modifications" rows="10" cols="50"></textarea><br />
+        <input id="imagen" placeholder="URL de la imagen" /><br />
+        <input id="titulo" placeholder="Título" /><br />
+        <input id="subtitulo" placeholder="Subtítulo" /><br />
+        <textarea id="beneficios" placeholder="Beneficios (uno por línea)" rows="5" cols="50"></textarea><br />
+        <input id="cta" placeholder="Texto del botón CTA" /><br />
         <button id="submit">Generate</button>
     </div>
 

--- a/web/main.js
+++ b/web/main.js
@@ -33,14 +33,20 @@
     });
 
     document.getElementById('submit').addEventListener('click', function() {
-        const mods = document.getElementById('modifications').value;
+        const payload = {
+            imagen: document.getElementById('imagen').value,
+            titulo: document.getElementById('titulo').value,
+            subtitulo: document.getElementById('subtitulo').value,
+            beneficios: document.getElementById('beneficios').value,
+            cta: document.getElementById('cta').value
+        };
         fetch(config.apiEndpoint, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'Authorization': idToken
             },
-            body: JSON.stringify({ modifications: mods })
+            body: JSON.stringify(payload)
         })
         .then(r => r.json())
         .then(data => {


### PR DESCRIPTION
## Summary
- document new JSON payload fields for the API
- update example `curl` command
- adjust web form and JavaScript to send `imagen`, `titulo`, `subtitulo`, `beneficios` and `cta`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848c17667dc83318b7547a1ec309b05